### PR TITLE
Remove leading slash from main path in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "homepage": "https://github.com/RonB/angular-oboe",
   "description": "Stream JSON data and add it page by page to your controller without having to use pagination serverside.",
-  "main": "/dist/angular-oboe.js",
+  "main": "dist/angular-oboe.js",
   "keywords": [
     "streaming",
     "json",


### PR DESCRIPTION
The leading slash in the path for the `main` option in the bower.json file was causing me some problems when using angular-oboe in the context of a Rails app. Removing the leading slash fixes those problems and brings things in line with best practices :smile: . Thanks!
